### PR TITLE
Add weblogin flow for NC > 12

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 set(synclib_NAME ${APPLICATION_EXECUTABLE}sync)
 
-find_package(Qt5 5.6 COMPONENTS Core Network Xml Concurrent REQUIRED)
+find_package(Qt5 5.6 COMPONENTS Core Network Xml Concurrent WebEngineWidgets WebEngine REQUIRED)
 if (Qt5Core_VERSION VERSION_LESS 5.9.0)
 message(STATUS "For HTTP/2 support, compile with Qt 5.9 or higher.")
 endif()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -287,7 +287,7 @@ else()
 endif()
 
 add_library(updater STATIC ${updater_SRCS})
-target_link_libraries(updater ${synclib_NAME} Qt5::Widgets Qt5::Network Qt5::Xml)
+target_link_libraries(updater ${synclib_NAME} Qt5::Widgets Qt5::Network Qt5::Xml Qt5::WebEngineWidgets)
 target_include_directories(updater PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 set_target_properties( ${APPLICATION_EXECUTABLE} PROPERTIES

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,7 +41,7 @@ set(client_UI_SRCS
     wizard/owncloudoauthcredspage.ui
     wizard/owncloudsetupnocredspage.ui
     wizard/owncloudwizardresultpage.ui
-    wizard/webviewpage.ui
+    wizard/webview.ui
 )
 
 set(client_SRCS
@@ -103,6 +103,7 @@ set(client_SRCS
     creds/httpcredentialsgui.cpp
     creds/oauth.cpp
     creds/webflowcredentials.cpp
+    creds/webflowcredentialsdialog.cpp
     wizard/postfixlineedit.cpp
     wizard/abstractcredswizardpage.cpp
     wizard/owncloudadvancedsetuppage.cpp
@@ -114,6 +115,7 @@ set(client_SRCS
     wizard/owncloudwizard.cpp
     wizard/owncloudwizardresultpage.cpp
     wizard/webviewpage.cpp
+    wizard/webview.cpp
 )
 
 IF(NOT NO_SHIBBOLETH)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -102,6 +102,7 @@ set(client_SRCS
     creds/credentialsfactory.cpp
     creds/httpcredentialsgui.cpp
     creds/oauth.cpp
+    creds/webflowcredentials.cpp
     wizard/postfixlineedit.cpp
     wizard/abstractcredswizardpage.cpp
     wizard/owncloudadvancedsetuppage.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,6 +41,7 @@ set(client_UI_SRCS
     wizard/owncloudoauthcredspage.ui
     wizard/owncloudsetupnocredspage.ui
     wizard/owncloudwizardresultpage.ui
+    wizard/webviewpage.ui
 )
 
 set(client_SRCS
@@ -111,6 +112,7 @@ set(client_SRCS
     wizard/owncloudwizardcommon.cpp
     wizard/owncloudwizard.cpp
     wizard/owncloudwizardresultpage.cpp
+    wizard/webviewpage.cpp
 )
 
 IF(NOT NO_SHIBBOLETH)

--- a/src/gui/creds/credentialsfactory.cpp
+++ b/src/gui/creds/credentialsfactory.cpp
@@ -21,6 +21,7 @@
 #ifndef NO_SHIBBOLETH
 #include "creds/shibbolethcredentials.h"
 #endif
+#include "creds/webflowcredentials.h"
 
 namespace OCC {
 
@@ -39,6 +40,8 @@ namespace CredentialsFactory {
         } else if (type == "shibboleth") {
             return new ShibbolethCredentials;
 #endif
+        } else if (type == "webflow") {
+            return new WebFlowCredentials;
         } else {
             qCWarning(lcGuiCredentials, "Unknown credentials type: %s", qPrintable(type));
             return new DummyCredentials;

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -219,6 +219,10 @@ void WebFlowCredentials::slotAuthentication(QNetworkReply *reply, QAuthenticator
 
 void WebFlowCredentials::slotFinished(QNetworkReply *reply) {
     qCInfo(lcWebFlowCredentials()) << "request finished";
+
+    if (reply->error() == QNetworkReply::NoError) {
+        _credentialsValid = true;
+    }
 }
 
 void WebFlowCredentials::fetchFromKeychainHelper() {

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -117,7 +117,7 @@ void WebFlowCredentials::slotAskFromUserCredentialsProvided(const QString &user,
         return;
     }
 
-    qCInfo(lcWebFlowCredentials()) << "New password is:" << pass;
+    qCInfo(lcWebFlowCredentials()) << "Obtained a new password";
 
     _password = pass;
     _ready = true;

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -1,5 +1,12 @@
 #include "webflowcredentials.h"
 
+#include "creds/httpcredentials.h"
+
+#include <QAuthenticator>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QPointer>
+#include <QTimer>
 #include <keychain.h>
 
 #include "accessmanager.h"
@@ -10,8 +17,11 @@ using namespace QKeychain;
 
 namespace OCC {
 
+Q_LOGGING_CATEGORY(lcWebFlowCredentials, "sync.credentials.webflow", QtInfoMsg)
+
 WebFlowCredentials::WebFlowCredentials()
-    : _ready(false)
+    : _ready(false),
+      _credentialsValid(false)
 {
 
 }
@@ -22,6 +32,7 @@ WebFlowCredentials::WebFlowCredentials(const QString &user, const QString &passw
     , _clientSslKey(key)
     , _clientSslCertificate(certificate)
     , _ready(true)
+    , _credentialsValid(true)
 {
 
 }
@@ -34,27 +45,58 @@ QString WebFlowCredentials::user() const {
     return _user;
 }
 
+QString WebFlowCredentials::password() const {
+    return _password;
+}
+
 QNetworkAccessManager *WebFlowCredentials::createQNAM() const {
+    qCInfo(lcWebFlowCredentials()) << "Get QNAM";
     AccessManager *qnam = new AccessManager();
+
+    connect(qnam, &AccessManager::authenticationRequired, this, &WebFlowCredentials::slotAuthentication);
+    connect(qnam, &AccessManager::finished, this, &WebFlowCredentials::slotFinished);
+
     return qnam;
 }
 
 bool WebFlowCredentials::ready() const {
-
+    return _ready;
 }
 
 void WebFlowCredentials::fetchFromKeychain() {
+    _wasFetched = true;
 
+    // Make sure we get the user fromt he config file
+    fetchUser();
+
+    if (ready()) {
+        emit fetched();
+    } else {
+        qCInfo(lcWebFlowCredentials()) << "Fetch from keyhchain!";
+        fetchFromKeychainHelper();
+    }
 }
-void WebFlowCredentials::askFromUser() {
 
+void WebFlowCredentials::askFromUser() {
+    qCWarning(lcWebFlowCredentials()) << "User needs to reauth!";
 }
 
 bool WebFlowCredentials::stillValid(QNetworkReply *reply) {
-
+    qCWarning(lcWebFlowCredentials()) << "Still valid?";
+    qCWarning(lcWebFlowCredentials()) << reply->error();
+    qCWarning(lcWebFlowCredentials()) << reply->errorString();
+    return (reply->error() != QNetworkReply::AuthenticationRequiredError);
 }
 
 void WebFlowCredentials::persist() {
+    if (_user.isEmpty()) {
+        // We don't even have a user nothing to see here move along
+        return;
+    }
+
+    _account->setCredentialSetting("user", _user);
+    _account->wantsAccountSaved(_account);
+
     //TODO: Add ssl cert and key storing
     WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());
     job->setInsecureFallback(false);
@@ -64,11 +106,97 @@ void WebFlowCredentials::persist() {
 }
 
 void WebFlowCredentials::invalidateToken() {
+    // clear the session cookie.
+    _account->clearCookieJar();
 
+    // let QNAM forget about the password
+    // This needs to be done later in the event loop because we might be called (directly or
+    // indirectly) from QNetworkAccessManagerPrivate::authenticationRequired, which itself
+    // is a called from a BlockingQueuedConnection from the Qt HTTP thread. And clearing the
+    // cache needs to synchronize again with the HTTP thread.
+    QTimer::singleShot(0, _account, &Account::clearQNAMCache);
 }
 
 void WebFlowCredentials::forgetSensitiveData(){
+    _password = QString();
+    _ready = false;
 
+    fetchUser();
+
+    const QString kck = keychainKey(_account->url().toString(), _user, _account->id());
+    if (kck.isEmpty()) {
+        qCWarning(lcWebFlowCredentials()) << "InvalidateToken: User is empty, bailing out!";
+        return;
+    }
+
+    DeletePasswordJob *job = new DeletePasswordJob(Theme::instance()->appName());
+    job->setInsecureFallback(false);
+    job->setKey(kck);
+    job->start();
+
+    invalidateToken();
+}
+
+void WebFlowCredentials::setAccount(Account *account) {
+    AbstractCredentials::setAccount(account);
+    if (_user.isEmpty()) {
+        fetchUser();
+    }
+}
+
+QString WebFlowCredentials::fetchUser() {
+    _user = _account->credentialSetting("user").toString();
+    return _user;
+}
+
+void WebFlowCredentials::slotAuthentication(QNetworkReply *reply, QAuthenticator *authenticator) {
+    Q_UNUSED(reply);
+
+    if (!_ready) {
+        return;
+    }
+
+    if (_credentialsValid == false) {
+        return;
+    }
+
+    qCWarning(lcWebFlowCredentials()) << "Requires authentication";
+
+    authenticator->setUser(_user);
+    authenticator->setPassword(_password);
+    _credentialsValid = false;
+}
+
+void WebFlowCredentials::slotFinished(QNetworkReply *reply) {
+    qCInfo(lcWebFlowCredentials()) << "request finished";
+}
+
+void WebFlowCredentials::fetchFromKeychainHelper() {
+    const QString kck = keychainKey(
+        _account->url().toString(),
+        _user,
+        _account->id());
+
+    ReadPasswordJob *job = new ReadPasswordJob(Theme::instance()->appName());
+    job->setInsecureFallback(false);
+    job->setKey(kck);
+    connect(job, &Job::finished, this, &WebFlowCredentials::slotReadPasswordJobDone);
+    job->start();
+}
+
+void WebFlowCredentials::slotReadPasswordJobDone(Job *incomingJob) {
+    QKeychain::ReadPasswordJob *job = static_cast<ReadPasswordJob *>(incomingJob);
+    QKeychain::Error error = job->error();
+
+    if (error == QKeychain::NoError) {
+        _password = job->textData();
+        _ready = true;
+        _credentialsValid = true;
+    } else {
+        _ready = false;
+    }
+
+    emit fetched();
 }
 
 }

--- a/src/gui/creds/webflowcredentials.cpp
+++ b/src/gui/creds/webflowcredentials.cpp
@@ -1,0 +1,74 @@
+#include "webflowcredentials.h"
+
+#include <keychain.h>
+
+#include "accessmanager.h"
+#include "account.h"
+#include "theme.h"
+
+using namespace QKeychain;
+
+namespace OCC {
+
+WebFlowCredentials::WebFlowCredentials()
+    : _ready(false)
+{
+
+}
+
+WebFlowCredentials::WebFlowCredentials(const QString &user, const QString &password, const QSslCertificate &certificate, const QSslKey &key)
+    : _user(user)
+    , _password(password)
+    , _clientSslKey(key)
+    , _clientSslCertificate(certificate)
+    , _ready(true)
+{
+
+}
+
+QString WebFlowCredentials::authType() const {
+    return QString::fromLatin1("webflow");
+}
+
+QString WebFlowCredentials::user() const {
+    return _user;
+}
+
+QNetworkAccessManager *WebFlowCredentials::createQNAM() const {
+    AccessManager *qnam = new AccessManager();
+    return qnam;
+}
+
+bool WebFlowCredentials::ready() const {
+
+}
+
+void WebFlowCredentials::fetchFromKeychain() {
+
+}
+void WebFlowCredentials::askFromUser() {
+
+}
+
+bool WebFlowCredentials::stillValid(QNetworkReply *reply) {
+
+}
+
+void WebFlowCredentials::persist() {
+    //TODO: Add ssl cert and key storing
+    WritePasswordJob *job = new WritePasswordJob(Theme::instance()->appName());
+    job->setInsecureFallback(false);
+    job->setKey(keychainKey(_account->url().toString(), _user, _account->id()));
+    job->setTextData(_password);
+    job->start();
+}
+
+void WebFlowCredentials::invalidateToken() {
+
+}
+
+void WebFlowCredentials::forgetSensitiveData(){
+
+}
+
+}

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -6,6 +6,13 @@
 
 #include "creds/abstractcredentials.h"
 
+class QNetworkReply;
+class QAuthenticator;
+
+namespace QKeychain {
+    class Job;
+}
+
 namespace OCC {
 
 class WebFlowCredentials : public AbstractCredentials
@@ -17,6 +24,7 @@ public:
 
     QString authType() const Q_DECL_OVERRIDE;
     QString user() const Q_DECL_OVERRIDE;
+    QString password() const;
     QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
 
     bool ready() const Q_DECL_OVERRIDE;
@@ -29,13 +37,34 @@ public:
     void invalidateToken() Q_DECL_OVERRIDE;
     void forgetSensitiveData() Q_DECL_OVERRIDE;
 
+    // To fetch the user name as early as possible
+    void setAccount(Account *account) Q_DECL_OVERRIDE;
+
+private slots:
+    void slotAuthentication(QNetworkReply *reply, QAuthenticator *authenticator);
+    void slotFinished(QNetworkReply *reply);
+
+    void slotReadPasswordJobDone(QKeychain::Job *incomingJob);
+
 private:
+    /** Reads data from keychain locations
+     *
+     * Goes through
+     *   slotReadClientCertPEMJobDone to
+     *   slotReadClientCertPEMJobDone to
+     *   slotReadJobDone
+     */
+    void fetchFromKeychainHelper();
+
+    QString fetchUser();
+
     QString _user;
     QString _password;
     QSslKey _clientSslKey;
     QSslCertificate _clientSslCertificate;
 
     bool _ready;
+    bool _credentialsValid;
 };
 
 }

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -6,6 +6,8 @@
 
 #include "creds/abstractcredentials.h"
 
+class QDialog;
+class QLabel;
 class QNetworkReply;
 class QAuthenticator;
 
@@ -14,6 +16,8 @@ namespace QKeychain {
 }
 
 namespace OCC {
+
+class WebFlowCredentialsDialog;
 
 class WebFlowCredentials : public AbstractCredentials
 {
@@ -45,6 +49,7 @@ private slots:
     void slotFinished(QNetworkReply *reply);
 
     void slotReadPasswordJobDone(QKeychain::Job *incomingJob);
+    void slotAskFromUserCredentialsProvided(const QString &user, const QString &pass, const QString &host);
 
 private:
     /** Reads data from keychain locations
@@ -65,6 +70,8 @@ private:
 
     bool _ready;
     bool _credentialsValid;
+
+    WebFlowCredentialsDialog *_askDialog;
 };
 
 }

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -26,23 +26,23 @@ public:
     explicit WebFlowCredentials();
     WebFlowCredentials(const QString &user, const QString &password, const QSslCertificate &certificate = QSslCertificate(), const QSslKey &key = QSslKey());
 
-    QString authType() const Q_DECL_OVERRIDE;
-    QString user() const Q_DECL_OVERRIDE;
+    QString authType() const override;
+    QString user() const override;
     QString password() const;
-    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
+    QNetworkAccessManager *createQNAM() const override;
 
-    bool ready() const Q_DECL_OVERRIDE;
+    bool ready() const override;
 
-    void fetchFromKeychain() Q_DECL_OVERRIDE;
-    void askFromUser() Q_DECL_OVERRIDE;
+    void fetchFromKeychain() override;
+    void askFromUser() override;
 
-    bool stillValid(QNetworkReply *reply) Q_DECL_OVERRIDE;
-    void persist() Q_DECL_OVERRIDE;
-    void invalidateToken() Q_DECL_OVERRIDE;
-    void forgetSensitiveData() Q_DECL_OVERRIDE;
+    bool stillValid(QNetworkReply *reply) override;
+    void persist() override;
+    void invalidateToken() override;
+    void forgetSensitiveData() override;
 
     // To fetch the user name as early as possible
-    void setAccount(Account *account) Q_DECL_OVERRIDE;
+    void setAccount(Account *account) override;
 
 private slots:
     void slotAuthentication(QNetworkReply *reply, QAuthenticator *authenticator);

--- a/src/gui/creds/webflowcredentials.h
+++ b/src/gui/creds/webflowcredentials.h
@@ -1,0 +1,43 @@
+#ifndef WEBFLOWCREDENTIALS_H
+#define WEBFLOWCREDENTIALS_H
+
+#include <QSslCertificate>
+#include <QSslKey>
+
+#include "creds/abstractcredentials.h"
+
+namespace OCC {
+
+class WebFlowCredentials : public AbstractCredentials
+{
+    Q_OBJECT
+public:
+    explicit WebFlowCredentials();
+    WebFlowCredentials(const QString &user, const QString &password, const QSslCertificate &certificate = QSslCertificate(), const QSslKey &key = QSslKey());
+
+    QString authType() const Q_DECL_OVERRIDE;
+    QString user() const Q_DECL_OVERRIDE;
+    QNetworkAccessManager *createQNAM() const Q_DECL_OVERRIDE;
+
+    bool ready() const Q_DECL_OVERRIDE;
+
+    void fetchFromKeychain() Q_DECL_OVERRIDE;
+    void askFromUser() Q_DECL_OVERRIDE;
+
+    bool stillValid(QNetworkReply *reply) Q_DECL_OVERRIDE;
+    void persist() Q_DECL_OVERRIDE;
+    void invalidateToken() Q_DECL_OVERRIDE;
+    void forgetSensitiveData() Q_DECL_OVERRIDE;
+
+private:
+    QString _user;
+    QString _password;
+    QSslKey _clientSslKey;
+    QSslCertificate _clientSslCertificate;
+
+    bool _ready;
+};
+
+}
+
+#endif // WEBFLOWCREDENTIALS_H

--- a/src/gui/creds/webflowcredentialsdialog.cpp
+++ b/src/gui/creds/webflowcredentialsdialog.cpp
@@ -1,0 +1,49 @@
+#include "webflowcredentialsdialog.h"
+
+#include <QVBoxLayout>
+#include <QLabel>
+
+#include "wizard/webview.h"
+
+namespace OCC {
+
+WebFlowCredentialsDialog::WebFlowCredentialsDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    _layout = new QVBoxLayout(this);
+
+    //QString msg = tr("You have been logged out of %1 as user %2, please login again")
+    //        .arg(_account->displayName(), _user);
+    _infoLabel = new QLabel();
+    _layout->addWidget(_infoLabel);
+
+    _webView = new WebView();
+    _layout->addWidget(_webView);
+
+    _errorLabel = new QLabel();
+    _errorLabel->hide();
+    _layout->addWidget(_errorLabel);
+
+    setLayout(_layout);
+
+    connect(_webView, &WebView::urlCatched, this, &WebFlowCredentialsDialog::urlCatched);
+}
+
+void WebFlowCredentialsDialog::setUrl(const QUrl &url) {
+    _webView->setUrl(url);
+}
+
+void WebFlowCredentialsDialog::setInfo(const QString &msg) {
+    _infoLabel->setText(msg);
+}
+
+void WebFlowCredentialsDialog::setError(const QString &error) {
+    if (error.isEmpty()) {
+        _errorLabel->hide();
+    } else {
+        _errorLabel->setText(error);
+        _errorLabel->show();
+    }
+}
+
+}

--- a/src/gui/creds/webflowcredentialsdialog.h
+++ b/src/gui/creds/webflowcredentialsdialog.h
@@ -1,0 +1,36 @@
+#ifndef WEBFLOWCREDENTIALSDIALOG_H
+#define WEBFLOWCREDENTIALSDIALOG_H
+
+#include <QDialog>
+#include <QUrl>
+
+class QLabel;
+class QVBoxLayout;
+
+namespace OCC {
+
+class WebView;
+
+class WebFlowCredentialsDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    WebFlowCredentialsDialog(QWidget *parent = 0);
+
+    void setUrl(const QUrl &url);
+    void setInfo(const QString &msg);
+    void setError(const QString &error);
+
+signals:
+    void urlCatched(const QString user, const QString pass, const QString host);
+
+private:
+    WebView *_webView;
+    QLabel *_errorLabel;
+    QLabel *_infoLabel;
+    QVBoxLayout *_layout;
+};
+
+}
+
+#endif // WEBFLOWCREDENTIALSDIALOG_H

--- a/src/gui/wizard/owncloudsetuppage.cpp
+++ b/src/gui/wizard/owncloudsetuppage.cpp
@@ -208,6 +208,8 @@ int OwncloudSetupPage::nextId() const
         return WizardCommon::Page_OAuthCreds;
     case DetermineAuthTypeJob::Shibboleth:
         return WizardCommon::Page_ShibbolethCreds;
+    case DetermineAuthTypeJob::WebViewFlow:
+        return WizardCommon::Page_WebView;
     }
     return WizardCommon::Page_HttpCreds;
 }

--- a/src/gui/wizard/owncloudwizard.h
+++ b/src/gui/wizard/owncloudwizard.h
@@ -39,6 +39,7 @@ class OwncloudAdvancedSetupPage;
 class OwncloudWizardResultPage;
 class AbstractCredentials;
 class AbstractCredentialsWizardPage;
+class WebViewPage;
 
 /**
  * @brief The OwncloudWizard class
@@ -103,6 +104,7 @@ private:
     OwncloudAdvancedSetupPage *_advancedSetupPage;
     OwncloudWizardResultPage *_resultPage;
     AbstractCredentialsWizardPage *_credentialsPage;
+    WebViewPage *_webViewPage;
 
     QStringList _setupLog;
 

--- a/src/gui/wizard/owncloudwizardcommon.h
+++ b/src/gui/wizard/owncloudwizardcommon.h
@@ -38,6 +38,7 @@ namespace WizardCommon {
         Page_HttpCreds,
         Page_ShibbolethCreds,
         Page_OAuthCreds,
+        Page_WebView,
         Page_AdvancedSetup,
         Page_Result
     };

--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -98,7 +98,7 @@ void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *reques
         }
     }
 
-    qCInfo(lcWizardWebiew()) << "Got user: " << user << ", password: " << password << ", server: " << server;
+    qCInfo(lcWizardWebiew()) << "Got user: " << user << ", server: " << server;
 
     emit urlCatched(user, password, server);
 }

--- a/src/gui/wizard/webview.cpp
+++ b/src/gui/wizard/webview.cpp
@@ -1,0 +1,108 @@
+#include "webview.h"
+
+#include <QWebEnginePage>
+#include <QWebEngineProfile>
+#include <QWebEngineUrlRequestInterceptor>
+#include <QWebEngineUrlRequestJob>
+#include <QWebEngineUrlSchemeHandler>
+#include <QWebEngineView>
+#include <QProgressBar>
+#include <QLoggingCategory>
+
+#include "common/utility.h"
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcWizardWebiew, "gui.wizard.webview", QtInfoMsg)
+
+
+class WebViewPageUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
+{
+    Q_OBJECT
+public:
+    WebViewPageUrlRequestInterceptor(QObject *parent = 0);
+    void interceptRequest(QWebEngineUrlRequestInfo &info);
+};
+
+class WebViewPageUrlSchemeHandler : public QWebEngineUrlSchemeHandler
+{
+    Q_OBJECT
+public:
+    WebViewPageUrlSchemeHandler(QObject *parent = 0);
+    void requestStarted(QWebEngineUrlRequestJob *request);
+
+Q_SIGNALS:
+    void urlCatched(QString user, QString pass, QString host);
+};
+
+
+WebView::WebView(QWidget *parent)
+    : QWidget(parent),
+      _ui()
+{
+    _ui.setupUi(this);
+
+    _webview = new QWebEngineView(this);
+    _profile = new QWebEngineProfile(this);
+    _page = new QWebEnginePage(_profile);
+    _interceptor = new WebViewPageUrlRequestInterceptor(this);
+    _schemeHandler = new WebViewPageUrlSchemeHandler(this);
+
+    _profile->setHttpUserAgent(Utility::userAgentString());
+    _profile->setRequestInterceptor(_interceptor);
+    _profile->installUrlSchemeHandler("nc", _schemeHandler);
+
+    _webview->setPage(_page);
+    _ui.verticalLayout->addWidget(_webview);
+    _webview->show();
+
+    connect(_webview, &QWebEngineView::loadProgress, _ui.progressBar, &QProgressBar::setValue);
+    connect(_schemeHandler, &WebViewPageUrlSchemeHandler::urlCatched, this, &WebView::urlCatched);
+}
+
+void WebView::setUrl(const QUrl &url) {
+    _page->setUrl(url);
+}
+
+WebViewPageUrlRequestInterceptor::WebViewPageUrlRequestInterceptor(QObject *parent)
+    : QWebEngineUrlRequestInterceptor(parent) {
+
+}
+
+void WebViewPageUrlRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo &info) {
+    info.setHttpHeader("OCS-APIREQUEST", "true");
+}
+
+WebViewPageUrlSchemeHandler::WebViewPageUrlSchemeHandler(QObject *parent)
+    : QWebEngineUrlSchemeHandler(parent) {
+
+}
+
+void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request) {
+    QUrl url = request->requestUrl();
+
+    QString path = url.path().mid(1);
+    QStringList parts = path.split("&");
+
+    QString server;
+    QString user;
+    QString password;
+
+    for (QString part : parts) {
+        if (part.startsWith("server:")) {
+            server = part.mid(7);
+        } else if (part.startsWith("user:")) {
+            user = part.mid(5);
+        } else if (part.startsWith("password:")) {
+            password = part.mid(9);
+        }
+    }
+
+    qCInfo(lcWizardWebiew()) << "Got user: " << user << ", password: " << password << ", server: " << server;
+
+    emit urlCatched(user, password, server);
+}
+
+}
+
+#include "webview.moc"

--- a/src/gui/wizard/webview.h
+++ b/src/gui/wizard/webview.h
@@ -1,0 +1,41 @@
+#ifndef WEBVIEW_H
+#define WEBVIEW_H
+
+#include <QUrl>
+#include <QWidget>
+
+#include "ui_webview.h"
+
+class QWebEngineView;
+class QWebEngineProfile;
+class QWebEnginePage;
+
+namespace OCC {
+
+class WebViewPageUrlRequestInterceptor;
+class WebViewPageUrlSchemeHandler;
+
+class WebView : public QWidget
+{
+    Q_OBJECT
+public:
+    WebView(QWidget *parent = 0);
+    void setUrl(const QUrl &url);
+
+signals:
+    void urlCatched(const QString user, const QString pass, const QString host);
+
+private:
+    Ui_WebView _ui;
+
+    QWebEngineView *_webview;
+    QWebEngineProfile *_profile;
+    QWebEnginePage *_page;
+
+    WebViewPageUrlRequestInterceptor *_interceptor;
+    WebViewPageUrlSchemeHandler *_schemeHandler;
+};
+
+}
+
+#endif // WEBVIEW_H

--- a/src/gui/wizard/webview.ui
+++ b/src/gui/wizard/webview.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>WebViewPage</class>
- <widget class="QWidget" name="WebViewPage">
+ <class>WebView</class>
+ <widget class="QWidget" name="WebView">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -26,6 +26,18 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="1" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <property name="spacing">

--- a/src/gui/wizard/webview.ui
+++ b/src/gui/wizard/webview.ui
@@ -53,7 +53,7 @@
        </property>
        <property name="styleSheet">
         <string notr="true">QProgressBar::chunk {
-    background-color: rgba(229, 26, 26, 255);
+    background-color: rgba(0, 130, 201, 255);
 }</string>
        </property>
        <property name="value">

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -3,7 +3,7 @@
 #include <QWebEngineUrlRequestJob>
 #include <QProgressBar>
 
-#include "creds/httpcredentialsgui.h"
+#include "creds/webflowcredentials.h"
 
 namespace OCC {
 
@@ -71,7 +71,7 @@ bool WebViewPage::isComplete() const {
 }
 
 AbstractCredentials* WebViewPage::getCredentials() const {
-    return new HttpCredentialsGui(_user, _pass, _ocWizard->_clientSslCertificate, _ocWizard->_clientSslKey);
+    return new WebFlowCredentials(_user, _pass, _ocWizard->_clientSslCertificate, _ocWizard->_clientSslKey);
 }
 
 void WebViewPage::setConnected() {

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -52,7 +52,7 @@ void WebViewPage::setConnected() {
 }
 
 void WebViewPage::urlCatched(QString user, QString pass, QString host) {
-    qCInfo(lcWizardWebiewPage()) << "Got user: " << user << ", password: " << pass << ", server: " << host;
+    qCInfo(lcWizardWebiewPage()) << "Got user: " << user << ", server: " << host;
 
     _user = user;
     _pass = pass;

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -2,64 +2,37 @@
 
 #include <QWebEngineUrlRequestJob>
 #include <QProgressBar>
+#include <QVBoxLayout>
 
+#include "owncloudwizard.h"
 #include "creds/webflowcredentials.h"
+#include "webview.h"
 
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcWizardWebiewPage, "gui.wizard.webviewpage", QtInfoMsg)
 
 
-class WebViewPageUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
-{
-    Q_OBJECT
-public:
-    WebViewPageUrlRequestInterceptor(QObject *parent = 0);
-    void interceptRequest(QWebEngineUrlRequestInfo &info);
-};
-
-class WebViewPageUrlSchemeHandler : public QWebEngineUrlSchemeHandler
-{
-    Q_OBJECT
-public:
-    WebViewPageUrlSchemeHandler(QObject *parent = 0);
-    void requestStarted(QWebEngineUrlRequestJob *request);
-
-Q_SIGNALS:
-    void urlCatched(QString user, QString pass, QString host);
-};
-
-
 WebViewPage::WebViewPage(QWidget *parent)
-    : AbstractCredentialsWizardPage(),
-      _ui()
+    : AbstractCredentialsWizardPage()
 {
-    _ui.setupUi(this);
     _ocWizard = qobject_cast<OwncloudWizard *>(parent);
 
-    _webview = new QWebEngineView(this);
-    _profile = new QWebEngineProfile(this);
-    _page = new QWebEnginePage(_profile);
-    _interceptor = new WebViewPageUrlRequestInterceptor(this);
-    _schemeHandler = new WebViewPageUrlSchemeHandler(this);
+    qCInfo(lcWizardWebiewPage()) << "Time for a webview!";
+    _webView = new WebView(this);
 
-    _profile->setHttpUserAgent(Utility::userAgentString());
-    _profile->setRequestInterceptor(_interceptor);
-    _profile->installUrlSchemeHandler("nc", _schemeHandler);
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addWidget(_webView);
+    setLayout(layout);
 
-    _webview->setPage(_page);
-    _ui.verticalLayout->addWidget(_webview);
-    _webview->show();
-
-    connect(_webview, &QWebEngineView::loadProgress, _ui.progressBar, &QProgressBar::setValue);
-    connect(_schemeHandler, &WebViewPageUrlSchemeHandler::urlCatched, this, &WebViewPage::urlCatched);
+    connect(_webView, &WebView::urlCatched, this, &WebViewPage::urlCatched);
 }
 
 void WebViewPage::initializePage() {
     auto url = _ocWizard->ocUrl();
     url += "/index.php/login/flow";
-    qCInfo(lcWizardWebiewPage()) << "Url to auth at: " << url;;
-    _page->setUrl(QUrl(url));
+    qCInfo(lcWizardWebiewPage()) << "Url to auth at: " << url;
+    _webView->setUrl(QUrl(url));
 }
 
 int WebViewPage::nextId() const {
@@ -88,45 +61,4 @@ void WebViewPage::urlCatched(QString user, QString pass, QString host) {
     emit connectToOCUrl(field("OCUrl").toString().simplified());
 }
 
-WebViewPageUrlRequestInterceptor::WebViewPageUrlRequestInterceptor(QObject *parent)
-    : QWebEngineUrlRequestInterceptor(parent) {
-
 }
-
-void WebViewPageUrlRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo &info) {
-    info.setHttpHeader("OCS-APIREQUEST", "true");
-}
-
-WebViewPageUrlSchemeHandler::WebViewPageUrlSchemeHandler(QObject *parent)
-    : QWebEngineUrlSchemeHandler(parent) {
-
-}
-
-void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request) {
-    QUrl url = request->requestUrl();
-
-    QString path = url.path().mid(1);
-    QStringList parts = path.split("&");
-
-    QString server;
-    QString user;
-    QString password;
-
-    for (QString part : parts) {
-        if (part.startsWith("server:")) {
-            server = part.mid(7);
-        } else if (part.startsWith("user:")) {
-            user = part.mid(5);
-        } else if (part.startsWith("password:")) {
-            password = part.mid(9);
-        }
-    }
-
-    qCInfo(lcWizardWebiewPage()) << "Got user: " << user << ", password: " << password << ", server: " << server;
-
-    emit urlCatched(user, password, server);
-}
-
-}
-
-#include "webviewpage.moc"

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -1,35 +1,56 @@
 #include "webviewpage.h"
 
+#include <QWebEngineUrlRequestJob>
+
 #include "creds/httpcredentialsgui.h"
 
 namespace OCC {
 
 Q_LOGGING_CATEGORY(lcWizardWebiewPage, "gui.wizard.webviewpage", QtInfoMsg)
 
+
+class WebViewPageUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
+{
+    Q_OBJECT
+public:
+    WebViewPageUrlRequestInterceptor(QObject *parent = 0);
+    void interceptRequest(QWebEngineUrlRequestInfo &info);
+};
+
+class WebViewPageUrlSchemeHandler : public QWebEngineUrlSchemeHandler
+{
+    Q_OBJECT
+public:
+    WebViewPageUrlSchemeHandler(QObject *parent = 0);
+    void requestStarted(QWebEngineUrlRequestJob *request);
+
+Q_SIGNALS:
+    void urlCatched(QString user, QString pass, QString host);
+};
+
+
 WebViewPage::WebViewPage(QWidget *parent)
     : AbstractCredentialsWizardPage(),
       _ui()
 {
-    _ocWizard = qobject_cast<OwncloudWizard *>(parent);
-
     _ui.setupUi(this);
-
-
+    _ocWizard = qobject_cast<OwncloudWizard *>(parent);
 
     _webview = new QWebEngineView(this);
     _profile = new QWebEngineProfile(this);
     _page = new QWebEnginePage(_profile);
     _interceptor = new WebViewPageUrlRequestInterceptor(this);
+    _schemeHandler = new WebViewPageUrlSchemeHandler(this);
 
     _profile->setHttpUserAgent(Utility::userAgentString());
     _profile->setRequestInterceptor(_interceptor);
+    _profile->installUrlSchemeHandler("nc", _schemeHandler);
 
     _webview->setPage(_page);
     _ui.verticalLayout->addWidget(_webview);
     _webview->show();
 
     connect(_webview, SIGNAL(loadProgress(int)), _ui.progressBar, SLOT(setValue(int)));
-
 }
 
 void WebViewPage::initializePage() {
@@ -64,4 +85,36 @@ void WebViewPageUrlRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo
     info.setHttpHeader("OCS-APIREQUEST", "true");
 }
 
+WebViewPageUrlSchemeHandler::WebViewPageUrlSchemeHandler(QObject *parent)
+    : QWebEngineUrlSchemeHandler(parent) {
+
 }
+
+void WebViewPageUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob *request) {
+    QUrl url = request->requestUrl();
+
+    QString path = url.path().mid(1);
+    QStringList parts = path.split("&");
+
+    QString server;
+    QString user;
+    QString password;
+
+    for (QString part : parts) {
+        if (part.startsWith("server:")) {
+            server = part.mid(7);
+        } else if (part.startsWith("user:")) {
+            user = part.mid(5);
+        } else if (part.startsWith("password:")) {
+            password = part.mid(9);
+        }
+    }
+
+    qCInfo(lcWizardWebiewPage()) << "Got user: " << user << ", password: " << password << ", server: " << server;
+
+    emit urlCatched(user, password, server);
+}
+
+}
+
+#include "webviewpage.moc"

--- a/src/gui/wizard/webviewpage.cpp
+++ b/src/gui/wizard/webviewpage.cpp
@@ -1,0 +1,67 @@
+#include "webviewpage.h"
+
+#include "creds/httpcredentialsgui.h"
+
+namespace OCC {
+
+Q_LOGGING_CATEGORY(lcWizardWebiewPage, "gui.wizard.webviewpage", QtInfoMsg)
+
+WebViewPage::WebViewPage(QWidget *parent)
+    : AbstractCredentialsWizardPage(),
+      _ui()
+{
+    _ocWizard = qobject_cast<OwncloudWizard *>(parent);
+
+    _ui.setupUi(this);
+
+
+
+    _webview = new QWebEngineView(this);
+    _profile = new QWebEngineProfile(this);
+    _page = new QWebEnginePage(_profile);
+    _interceptor = new WebViewPageUrlRequestInterceptor(this);
+
+    _profile->setHttpUserAgent(Utility::userAgentString());
+    _profile->setRequestInterceptor(_interceptor);
+
+    _webview->setPage(_page);
+    _ui.verticalLayout->addWidget(_webview);
+    _webview->show();
+
+    connect(_webview, SIGNAL(loadProgress(int)), _ui.progressBar, SLOT(setValue(int)));
+
+}
+
+void WebViewPage::initializePage() {
+    auto url = _ocWizard->ocUrl();
+    url += "/index.php/login/flow";
+    qCInfo(lcWizardWebiewPage()) << "Url to auth at: " << url;;
+    _page->setUrl(QUrl(url));
+}
+
+int WebViewPage::nextId() const {
+    return WizardCommon::Page_AdvancedSetup;
+}
+
+bool WebViewPage::isComplete() const {
+    return false;
+}
+
+AbstractCredentials* WebViewPage::getCredentials() const {
+    return new HttpCredentialsGui();
+}
+
+void WebViewPage::setConnected() {
+
+}
+
+WebViewPageUrlRequestInterceptor::WebViewPageUrlRequestInterceptor(QObject *parent)
+    : QWebEngineUrlRequestInterceptor(parent) {
+
+}
+
+void WebViewPageUrlRequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo &info) {
+    info.setHttpHeader("OCS-APIREQUEST", "true");
+}
+
+}

--- a/src/gui/wizard/webviewpage.h
+++ b/src/gui/wizard/webviewpage.h
@@ -1,23 +1,13 @@
 #ifndef WEBVIEWPAGE_H
 #define WEBVIEWPAGE_H
 
-#include <QWizard>
-#include <QWebEngineView>
-#include <QWebEngineProfile>
-#include <QWebEnginePage>
-#include <QWebEngineUrlRequestInterceptor>
-#include <QWebEngineUrlSchemeHandler>
-
 #include "wizard/abstractcredswizardpage.h"
-#include "wizard/owncloudwizardcommon.h"
-#include "wizard/owncloudwizard.h"
-
-#include "ui_webviewpage.h"
 
 namespace OCC {
 
-class WebViewPageUrlRequestInterceptor;
-class WebViewPageUrlSchemeHandler;
+class AbstractCredentials;
+class OwncloudWizard;
+class WebView;
 
 class WebViewPage : public AbstractCredentialsWizardPage
 {
@@ -32,22 +22,15 @@ public:
     AbstractCredentials* getCredentials() const;
     void setConnected();
 
-Q_SIGNALS:
+signals:
     void connectToOCUrl(const QString&);
 
 private slots:
     void urlCatched(QString user, QString pass, QString host);
 
 private:
-    Ui_WebViewPage _ui;
     OwncloudWizard *_ocWizard;
-
-    QWebEngineView *_webview;
-    QWebEngineProfile *_profile;
-    QWebEnginePage *_page;
-
-    WebViewPageUrlRequestInterceptor *_interceptor;
-    WebViewPageUrlSchemeHandler *_schemeHandler;
+    WebView *_webView;
 
     QString _user;
     QString _pass;

--- a/src/gui/wizard/webviewpage.h
+++ b/src/gui/wizard/webviewpage.h
@@ -1,0 +1,54 @@
+#ifndef WEBVIEWPAGE_H
+#define WEBVIEWPAGE_H
+
+#include <QWizard>
+#include <QWebEngineView>
+#include <QWebEngineProfile>
+#include <QWebEnginePage>
+#include <QWebEngineUrlRequestInterceptor>
+
+#include "wizard/abstractcredswizardpage.h"
+#include "wizard/owncloudwizardcommon.h"
+#include "wizard/owncloudwizard.h"
+
+#include "ui_webviewpage.h"
+
+namespace OCC {
+
+class WebViewPageUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
+{
+    Q_OBJECT
+public:
+    WebViewPageUrlRequestInterceptor(QObject *parent = 0);
+    void interceptRequest(QWebEngineUrlRequestInfo &info);
+};
+
+class WebViewPage : public AbstractCredentialsWizardPage
+{
+    Q_OBJECT
+public:
+    WebViewPage(QWidget *parent = 0);
+
+    void initializePage() Q_DECL_OVERRIDE;
+    int nextId() const Q_DECL_OVERRIDE;
+    bool isComplete() const;
+
+    AbstractCredentials* getCredentials() const;
+    void setConnected();
+
+Q_SIGNALS:
+    void connectToOCUrl(const QString&);
+
+private:
+    Ui_WebViewPage _ui;
+    OwncloudWizard *_ocWizard;
+
+    QWebEngineView *_webview;
+    QWebEngineProfile *_profile;
+    QWebEnginePage *_page;
+    WebViewPageUrlRequestInterceptor *_interceptor;
+};
+
+}
+
+#endif // WEBVIEWPAGE_H

--- a/src/gui/wizard/webviewpage.h
+++ b/src/gui/wizard/webviewpage.h
@@ -35,6 +35,9 @@ public:
 Q_SIGNALS:
     void connectToOCUrl(const QString&);
 
+private slots:
+    void urlCatched(QString user, QString pass, QString host);
+
 private:
     Ui_WebViewPage _ui;
     OwncloudWizard *_ocWizard;
@@ -45,6 +48,9 @@ private:
 
     WebViewPageUrlRequestInterceptor *_interceptor;
     WebViewPageUrlSchemeHandler *_schemeHandler;
+
+    QString _user;
+    QString _pass;
 };
 
 }

--- a/src/gui/wizard/webviewpage.h
+++ b/src/gui/wizard/webviewpage.h
@@ -6,6 +6,7 @@
 #include <QWebEngineProfile>
 #include <QWebEnginePage>
 #include <QWebEngineUrlRequestInterceptor>
+#include <QWebEngineUrlSchemeHandler>
 
 #include "wizard/abstractcredswizardpage.h"
 #include "wizard/owncloudwizardcommon.h"
@@ -15,13 +16,8 @@
 
 namespace OCC {
 
-class WebViewPageUrlRequestInterceptor : public QWebEngineUrlRequestInterceptor
-{
-    Q_OBJECT
-public:
-    WebViewPageUrlRequestInterceptor(QObject *parent = 0);
-    void interceptRequest(QWebEngineUrlRequestInfo &info);
-};
+class WebViewPageUrlRequestInterceptor;
+class WebViewPageUrlSchemeHandler;
 
 class WebViewPage : public AbstractCredentialsWizardPage
 {
@@ -46,7 +42,9 @@ private:
     QWebEngineView *_webview;
     QWebEngineProfile *_profile;
     QWebEnginePage *_page;
+
     WebViewPageUrlRequestInterceptor *_interceptor;
+    WebViewPageUrlSchemeHandler *_schemeHandler;
 };
 
 }

--- a/src/gui/wizard/webviewpage.ui
+++ b/src/gui/wizard/webviewpage.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>WebViewPage</class>
+ <widget class="QWidget" name="WebViewPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>800</width>
+    <height>650</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QProgressBar" name="progressBar">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>5</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QProgressBar::chunk {
+    background-color: rgba(229, 26, 26, 255);
+}</string>
+       </property>
+       <property name="value">
+        <number>0</number>
+       </property>
+       <property name="textVisible">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="resultLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/libsync/networkjobs.cpp
+++ b/src/libsync/networkjobs.cpp
@@ -921,6 +921,12 @@ void DetermineAuthTypeJob::checkBothDone()
     // OAuth > Shib > Basic
     if (_resultGet == Shibboleth && result != OAuth)
         result = Shibboleth;
+
+    // WebViewFlow > OAuth > Shib > Basic
+    if (_account->serverVersionInt() >= Account::makeServerVersion(12, 0, 0)) {
+        result = WebViewFlow;
+    }
+
     qCInfo(lcDetermineAuthTypeJob) << "Auth type for" << _account->davUrl() << "is" << result;
     emit authType(result);
     deleteLater();

--- a/src/libsync/networkjobs.h
+++ b/src/libsync/networkjobs.h
@@ -411,7 +411,8 @@ public:
     enum AuthType {
         Basic, // also the catch-all fallback for backwards compatibility reasons
         OAuth,
-        Shibboleth
+        Shibboleth,
+        WebViewFlow
     };
 
     explicit DetermineAuthTypeJob(AccountPtr account, QObject *parent = 0);


### PR DESCRIPTION
Finally support the new login flow that was introduced with NC 12.

This requires at QWebEngine.

It will simply open a webview to the login flow and fetch an apptoken from that endpoint.
This is all stored in the Keychain.

If for some reason a reauth is required the user is prompted to login again.