### PR TITLE
Add windows cross-compilation to drone / fix build error

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,21 @@ pipeline:
             matrix:
                 TESTS: qt-5.9
 
+    windows:
+        image: juliushaertl/testing-nc-client
+        commands:
+            - rm -rf build-win32
+            - mkdir build-win32
+            - cd build-win32
+            - ../admin/win/download_runtimes.sh
+            - cmake .. -DCMAKE_TOOLCHAIN_FILE=../admin/win/Toolchain-mingw32-openSUSE.cmake -DWITH_CRASHREPORTER=ON
+            - make -j4
+            - make package
+            - ctest .
+        when:
+            matrix:
+                TESTS: windows
+
     AppImage-5.9:
         image: nextcloudci/client-appimage-ci:client-appimage-ci-6
         commands:
@@ -93,6 +108,7 @@ matrix:
         - TESTS: qt-5.7
         - TESTS: qt-5.8
         - TESTS: qt-5.9
+        - TESTS: windows
         - BUILD: AppImage
 
 branches: [ master, 2.* ]

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -42,8 +42,10 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QSignalMapper>
+#ifdef WITH_LIBCLOUDPROVIDERS
 #include <QtDBus/QDBusConnection>
 #include <QtDBus/QDBusInterface>
+#endif
 
 #if defined(Q_OS_X11)
 #include <QX11Info>
@@ -66,7 +68,9 @@ ownCloudGui::ownCloudGui(Application *parent)
 #endif
     _logBrowser(0)
     , _contextMenuVisibleOsx(false)
+#ifdef WITH_LIBCLOUDPROVIDERS
     , _bus(QDBusConnection::sessionBus())
+#endif
     , _recentActionsMenu(0)
     , _qdbusmenuWorkaround(false)
     , _app(parent)

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -25,7 +25,9 @@
 #include <QMenu>
 #include <QSize>
 #include <QTimer>
+#ifdef WITH_LIBCLOUDPROVIDERS
 #include <QDBusConnection>
+#endif
 
 namespace OCC {
 
@@ -128,7 +130,9 @@ private:
     // on OSX because aboutToHide is not reliable everywhere.
     bool _contextMenuVisibleOsx;
 
+#ifdef WITH_LIBCLOUDPROVIDERS
     QDBusConnection _bus;
+#endif
 
     QMenu *_recentActionsMenu;
     QVector<QMenu *> _accountMenus;


### PR DESCRIPTION
- Make headers be only included when building with libcloudprovider support (fixes #93)
- Add windows build to drone

Requires https://github.com/nextcloud/docker-ci/pull/68

TODO:
- [ ] update container name once https://github.com/nextcloud/docker-ci/pull/68 is available