### PR TITLE
Uses QString::number to get a string equivalent of the notification_id number 

### DIFF
--- a/src/gui/servernotificationhandler.cpp
+++ b/src/gui/servernotificationhandler.cpp
@@ -101,7 +101,7 @@ void ServerNotificationHandler::slotNotificationsReceived(const QJsonDocument &j
         // https://github.com/owncloud/notifications/blob/master/docs/ocs-endpoint-v1.md#deleting-a-notification-for-a-user
         ActivityLink al;
         al._label = tr("Dismiss");
-        al._link  = Utility::concatUrlPath(ai->account()->url(), notificationsPath + "/" + json.value("notification_id").toString()).toString();
+        al._link  = Utility::concatUrlPath(ai->account()->url(), notificationsPath + "/" + QString::number(a._id)).toString();
         al._verb  = "DELETE";
         al._isPrimary = false;
         a._links.append(al);


### PR DESCRIPTION
Fixes bug reported #117.
