### PR TITLE
Dolphin plugin path correction

### DIFF
--- a/admin/linux/debian/debian.artful/nextcloud-client-dolphin.install
+++ b/admin/linux/debian/debian.artful/nextcloud-client-dolphin.install
@@ -1,4 +1,0 @@
-usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
-usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/admin/linux/debian/debian.bionic/nextcloud-client-dolphin.install
+++ b/admin/linux/debian/debian.bionic/nextcloud-client-dolphin.install
@@ -1,4 +1,0 @@
-usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
-usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/admin/linux/debian/debian/nextcloud-client-dolphin.install
+++ b/admin/linux/debian/debian/nextcloud-client-dolphin.install
@@ -1,4 +1,4 @@
 usr/lib/*/libnextclouddolphinpluginhelper.so
-usr/lib/*/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
-usr/lib/*/plugins/nextclouddolphinactionplugin.so
+usr/lib/*/qt5/plugins/kf5/overlayicon/nextclouddolphinoverlayplugin.so
+usr/lib/*/qt5/plugins/nextclouddolphinactionplugin.so
 usr/share/kservices5/nextclouddolphinactionplugin.desktop

--- a/shell_integration/dolphin/CMakeLists.txt
+++ b/shell_integration/dolphin/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8.12)
 include(FeatureSummary)
 set(QT_MIN_VERSION "5.3.0")
 set(KF5_MIN_VERSION "5.16.0")
+set(KDE_INSTALL_USE_QT_SYS_PATHS ON CACHE BOOL "Install the plugin in the right directory")
 
 find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Network)
 


### PR DESCRIPTION
When building for Xenial the Dolphin plugins go into the incorrect directory. This patch sets the KDE_INSTALL_USE_QT_SYS_PATHS cmake variable to ON, which seems to be the most generic way to solve this issue.