### PR TITLE
Recommends relation to libgnome-keyring0

### DIFF
--- a/admin/linux/debian/debian.stable/control
+++ b/admin/linux/debian/debian.stable/control
@@ -33,6 +33,7 @@ Homepage: https://github.com/nextcloud/client_theming
 Package: nextcloud-client
 Architecture: any
 Depends: libnextcloudsync0 (=${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, nextcloud-client-l10n
+Recommends: libgnome-keyring0
 Description: Nextcloud desktop sync client
  Use the desktop client to keep your files synchronized
  between your Nextcloud server and your desktop. Select

--- a/admin/linux/debian/debian/control
+++ b/admin/linux/debian/debian/control
@@ -33,6 +33,7 @@ Homepage: https://github.com/nextcloud/client_theming
 Package: nextcloud-client
 Architecture: any
 Depends: libnextcloudsync0 (=${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, nextcloud-client-l10n
+Recommends: libgnome-keyring0
 Description: Nextcloud desktop sync client
  Use the desktop client to keep your files synchronized
  between your Nextcloud server and your desktop. Select


### PR DESCRIPTION
It has been suggested that the libgnome-keyring0 package is useful when one wants to use the GNOME keyring. So the nextcloud-client package now recommends libgnome-keyring0.

This resolves #181.