### PR TITLE
Fix sync status running when encryption data is missing

### DIFF
--- a/src/libsync/propagatedownload.cpp
+++ b/src/libsync/propagatedownload.cpp
@@ -359,6 +359,10 @@ void PropagateDownloadFile::start()
           _isEncrypted = true;
           startAfterIsEncryptedIsChecked();
         });
+        connect(_downloadEncryptedHelper, &PropagateDownloadEncrypted::failed, [this] {
+          done(SyncFileItem::NormalError,
+               tr("File %1 can not be downloaded because encryption information is missing.").arg(QDir::toNativeSeparators(_item->_file)));
+        });
         _downloadEncryptedHelper->start();
     } else {
         startAfterIsEncryptedIsChecked();

--- a/src/libsync/propagatedownloadencrypted.cpp
+++ b/src/libsync/propagatedownloadencrypted.cpp
@@ -78,6 +78,7 @@ void PropagateDownloadEncrypted::checkFolderEncryptedMetadata(const QJsonDocumen
   const QString filename = _info.fileName();
   auto meta = new FolderMetadata(_propagator->account(), json.toJson(QJsonDocument::Compact));
   const QVector<EncryptedFile> files = meta->files();
+
   for (const EncryptedFile &file : files) {
     qCDebug(lcPropagateDownloadEncrypted) << "file" << filename << file.encryptedFilename << file.originalFilename << file.encryptionKey;
     if (filename == file.encryptedFilename) {
@@ -88,7 +89,8 @@ void PropagateDownloadEncrypted::checkFolderEncryptedMetadata(const QJsonDocumen
     }
   }
 
-  qCDebug(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << filename;
+  emit failed();
+  qCCritical(lcPropagateDownloadEncrypted) << "Failed to find encrypted metadata information of remote file" << filename;
 }
 
 // TODO: Fix this. Exported in the wrong place.

--- a/src/libsync/propagatedownloadencrypted.h
+++ b/src/libsync/propagatedownloadencrypted.h
@@ -31,6 +31,7 @@ public slots:
 signals:
   void folderStatusEncrypted();
   void folderStatusNotEncrypted();
+  void failed();
 
   void decryptionFinished();
 

--- a/src/libsync/wordlist.cpp
+++ b/src/libsync/wordlist.cpp
@@ -1,3 +1,4 @@
+
 #include "wordlist.h"
 #include <openssl/rand.h>
 


### PR DESCRIPTION
When a file on the server of an encrypted folder do
not have a matching entry on the JSON metadata, we
need to report an error and be done with the job
so that Sync status is not "running".

This eventually should cause the file to be removed
from the server as it can not be recovered anymore.