### PR TITLE
Checks for 304 response in the navigation apps request

### DIFF
--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -187,6 +187,16 @@ void AccountState::setNotificationsEtagResponseHeader(const QByteArray &value)
     _notificationsEtagResponseHeader = value;
 }
 
+QByteArray AccountState::navigationAppsEtagResponseHeader() const
+{
+    return _navigationAppsEtagResponseHeader;
+}
+
+void AccountState::setNavigationAppsEtagResponseHeader(const QByteArray &value)
+{
+    _navigationAppsEtagResponseHeader = value;
+}
+
 void AccountState::checkConnectivity()
 {
     if (isSignedOut() || _waitingForNewCredentials) {

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -141,6 +141,16 @@ public:
     */
     void setNotificationsEtagResponseHeader(const QByteArray &value);
 
+    /** Saves the ETag Response header from the last Navigation Apps api
+     * request with statusCode 200.
+    */
+    QByteArray navigationAppsEtagResponseHeader() const;
+
+    /** Returns the ETag Response header from the last Navigation Apps api
+     * request with statusCode 200.
+    */
+    void setNavigationAppsEtagResponseHeader(const QByteArray &value);
+
 public slots:
     /// Triggers a ping to the server to update state and
     /// connection status and errors.
@@ -168,6 +178,7 @@ private:
     QElapsedTimer _timeSinceLastETagCheck;
     QPointer<ConnectionValidator> _connectionValidator;
     QByteArray _notificationsEtagResponseHeader;
+    QByteArray _navigationAppsEtagResponseHeader;
 
     /**
      * Starts counting when the server starts being back up after 503 or

--- a/src/gui/ocsjob.h
+++ b/src/gui/ocsjob.h
@@ -26,6 +26,8 @@
 #define OCS_SUCCESS_STATUS_CODE 100
 // Apparantly the v2.php URLs can return that
 #define OCS_SUCCESS_STATUS_CODE_V2 200
+// not modified when using  ETag
+#define OCS_NOT_MODIFIED_STATUS_CODE_V2 304
 
 class QJsonDocument;
 
@@ -99,6 +101,14 @@ public:
      */
     static int getJsonReturnCode(const QJsonDocument &json, QString &message);
 
+    /**
+     * @brief Adds header to the request e.g. "If-None-Match"
+     * @param headerName a string with the header name
+     * @param value a string with the value
+     */
+    void addRawHeader(const QByteArray &headerName, const QByteArray &value);
+
+
 protected slots:
 
     /**
@@ -113,7 +123,7 @@ signals:
      *
      * @param reply the reply
      */
-    void jobFinished(QJsonDocument reply);
+    void jobFinished(QJsonDocument reply, int statusCode);
 
     /**
      * The status code was not one of the expected (passing)
@@ -124,6 +134,14 @@ signals:
      */
     void ocsError(int statusCode, const QString &message);
 
+    /**
+     * @brief etagResponseHeaderReceived - signal to report the ETag response header value
+     * from ocs api v2
+     * @param value - the ETag response header value
+     * @param statusCode - the OCS status code: 100 (!) for success
+     */
+    void etagResponseHeaderReceived(const QByteArray &value, int statusCode);
+
 private slots:
     virtual bool finished() Q_DECL_OVERRIDE;
 
@@ -131,6 +149,7 @@ private:
     QByteArray _verb;
     QList<QPair<QString, QString>> _params;
     QVector<int> _passStatusCodes;
+    QNetworkRequest _request;
 };
 }
 

--- a/src/gui/ocsnavigationappsjob.cpp
+++ b/src/gui/ocsnavigationappsjob.cpp
@@ -30,9 +30,8 @@ void OcsNavigationAppsJob::getNavigationApps()
     start();
 }
 
-void OcsNavigationAppsJob::jobDone(const QJsonDocument &reply)
+void OcsNavigationAppsJob::jobDone(const QJsonDocument &reply, int statusCode)
 {
-
-    emit appsJobFinished(reply);
+    emit appsJobFinished(reply, statusCode);
 }
 }

--- a/src/gui/ocsnavigationappsjob.h
+++ b/src/gui/ocsnavigationappsjob.h
@@ -43,11 +43,12 @@ signals:
      * Result of the OCS request
      *
      * @param reply The reply
+     * @param statusCode the status code of the response
      */
-    void appsJobFinished(const QJsonDocument &reply);
+    void appsJobFinished(const QJsonDocument &reply, int statusCode);
 
 private slots:
-    void jobDone(const QJsonDocument &reply);
+    void jobDone(const QJsonDocument &reply, int statusCode);
 };
 }
 

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -740,57 +740,87 @@ void ownCloudGui::setupActions()
     }
 }
 
+void ownCloudGui::slotEtagResponseHeaderReceived(const QByteArray &value, int statusCode){
+    if(statusCode == 200){
+        qCWarning(lcApplication) << "New navigation apps ETag Response Header received " << value;
+        auto account = qvariant_cast<AccountStatePtr>(sender()->property(propertyAccountC));
+        account->setNavigationAppsEtagResponseHeader(value);
+    }
+}
+
 void ownCloudGui::fetchNavigationApps(AccountStatePtr account, QMenu *accountMenu){
     OcsNavigationAppsJob *job = new OcsNavigationAppsJob(account->account());
-    job->setProperty(propertyAccountC, QVariant::fromValue(account->account()));
+    job->setProperty(propertyAccountC, QVariant::fromValue(account));
     job->setProperty(propertyMenuC, QVariant::fromValue(accountMenu));
+    job->addRawHeader("If-None-Match", account->navigationAppsEtagResponseHeader());
     connect(job, &OcsNavigationAppsJob::appsJobFinished, this, &ownCloudGui::slotNavigationAppsFetched);
+    connect(job, &OcsNavigationAppsJob::etagResponseHeaderReceived, this, &ownCloudGui::slotEtagResponseHeaderReceived);
     connect(job, &OcsNavigationAppsJob::ocsError, this, &ownCloudGui::slotOcsError);
     job->getNavigationApps();
 }
 
-void ownCloudGui::slotNavigationAppsFetched(const QJsonDocument &reply)
-{
-    if(!reply.isEmpty()){
-        auto element = reply.object().value("ocs").toObject().value("data");
-        auto navLinks = element.toArray();
+void ownCloudGui::buildNavigationAppsMenu(QMenu *accountMenu){
+    QMapIterator<AccountStatePtr, QJsonArray> it(_navApps);
+    while(it.hasNext()){
+
+        //qDebug() << it.key() << it.value();
+
+        auto account = it.key();
+        auto navLinks = it.value();
+
         if(navLinks.size() > 0){
-            if(auto account = qvariant_cast<AccountPtr>(sender()->property(propertyAccountC))){
-                if(QMenu *accountMenu = qvariant_cast<QMenu*>(sender()->property(propertyMenuC))){
 
-                    // when there is only one account add the nav links above the settings
-                    QAction *actionBefore = _actionSettings;
+            // when there is only one account add the nav links above the settings
+            QAction *actionBefore = _actionSettings;
 
-                    // when there is more than one account add the nav links above pause/unpause folder or logout action
-                    if(AccountManager::instance()->accounts().size() > 1){
-                        foreach(QAction *action, accountMenu->actions()){
+            // when there is more than one account add the nav links above pause/unpause folder or logout action
+            if(AccountManager::instance()->accounts().size() > 1){
+                foreach(QAction *action, accountMenu->actions()){
 
-                            // pause/unpause folder and logout actions have propertyAccountC
-                            if(auto actionAccount = qvariant_cast<AccountStatePtr>(action->property(propertyAccountC))){
-                                if(actionAccount->account() == account){
-                                    actionBefore = action;
-                                    break;
-                                }
-                             }
+                    // pause/unpause folder and logout actions have propertyAccountC
+                    if(auto actionAccount = qvariant_cast<AccountStatePtr>(action->property(propertyAccountC))){
+                        if(actionAccount == account){
+                            actionBefore = action;
+                            break;
                         }
                     }
-
-                    // Create submenu with links
-                    QMenu *navLinksMenu = new QMenu(tr("Apps"));
-                    accountMenu->insertSeparator(actionBefore);
-                    accountMenu->insertMenu(actionBefore, navLinksMenu);
-                    foreach (const QJsonValue &value, navLinks) {
-                        auto navLink = value.toObject();
-                        QAction *action = new QAction(navLink.value("name").toString(), this);
-                        QUrl href(navLink.value("href").toString());
-                        connect(action, &QAction::triggered, this, [href] { QDesktopServices::openUrl(href); });
-                        navLinksMenu->addAction(action);
-                    }
-                    accountMenu->insertSeparator(actionBefore);
                 }
             }
+
+            // Create submenu with links
+            QMenu *navLinksMenu = new QMenu(tr("Apps"));
+            accountMenu->insertSeparator(actionBefore);
+            accountMenu->insertMenu(actionBefore, navLinksMenu);
+            foreach (const QJsonValue &value, navLinks) {
+                auto navLink = value.toObject();
+                QAction *action = new QAction(navLink.value("name").toString(), this);
+                QUrl href(navLink.value("href").toString());
+                connect(action, &QAction::triggered, this, [href] { QDesktopServices::openUrl(href); });
+                navLinksMenu->addAction(action);
+            }
+            accountMenu->insertSeparator(actionBefore);
         }
+
+        it.next();
     }
+}
+
+void ownCloudGui::slotNavigationAppsFetched(const QJsonDocument &reply, int statusCode)
+{
+    if (statusCode == 304) {
+        qCWarning(lcApplication) << "Status code " << statusCode << " Not Modified - No new navigation apps.";
+    } else {
+        if(!reply.isEmpty()){
+            auto element = reply.object().value("ocs").toObject().value("data");
+            auto navLinks = element.toArray();
+            if(auto account = qvariant_cast<AccountStatePtr>(sender()->property(propertyAccountC))){
+                _navApps.insert(account, navLinks);
+            }
+         }
+    }
+
+    if(QMenu *accountMenu = qvariant_cast<QMenu*>(sender()->property(propertyMenuC)))
+        buildNavigationAppsMenu(accountMenu);
 }
 
 void ownCloudGui::slotOcsError(int statusCode, const QString &message)

--- a/src/gui/owncloudgui.cpp
+++ b/src/gui/owncloudgui.cpp
@@ -742,7 +742,7 @@ void ownCloudGui::setupActions()
 
 void ownCloudGui::slotEtagResponseHeaderReceived(const QByteArray &value, int statusCode){
     if(statusCode == 200){
-        qCWarning(lcApplication) << "New navigation apps ETag Response Header received " << value;
+        qCDebug(lcApplication) << "New navigation apps ETag Response Header received " << value;
         auto account = qvariant_cast<AccountStatePtr>(sender()->property(propertyAccountC));
         account->setNavigationAppsEtagResponseHeader(value);
     }

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -123,7 +123,7 @@ private:
     void setupActions();
     void addAccountContextMenu(AccountStatePtr accountState, QMenu *menu, bool separateMenu);
     void fetchNavigationApps(AccountStatePtr account, QMenu *accountMenu);
-    void buildNavigationAppsMenu(QMenu *accountMenu);
+    void buildNavigationAppsMenu(AccountStatePtr account, QMenu *accountMenu);
 
     QPointer<Systray> _tray;
 #if defined(Q_OS_MAC)

--- a/src/gui/owncloudgui.h
+++ b/src/gui/owncloudgui.h
@@ -93,7 +93,9 @@ public slots:
     void slotOpenPath(const QString &path);
     void slotAccountStateChanged();
     void slotTrayMessageIfServerUnsupported(Account *account);
-    void slotNavigationAppsFetched(const QJsonDocument &reply);
+    void slotNavigationAppsFetched(const QJsonDocument &reply, int statusCode);
+    void slotEtagResponseHeaderReceived(const QByteArray &value, int statusCode);
+
 
     /**
      * Open a share dialog for a file or folder.
@@ -121,6 +123,7 @@ private:
     void setupActions();
     void addAccountContextMenu(AccountStatePtr accountState, QMenu *menu, bool separateMenu);
     void fetchNavigationApps(AccountStatePtr account, QMenu *accountMenu);
+    void buildNavigationAppsMenu(QMenu *accountMenu);
 
     QPointer<Systray> _tray;
 #if defined(Q_OS_MAC)
@@ -154,6 +157,8 @@ private:
     QAction *_actionHelp;
     QAction *_actionQuit;
     QAction *_actionCrash;
+
+    QMap<AccountStatePtr, QJsonArray> _navApps;
 
     QList<QAction *> _recentItemsActions;
     Application *_app;


### PR DESCRIPTION
I am trying to use the 304 ETag response header to check for changes in the server. But I am not sure if I can do much better than just changing the list of navigation apps once I get 200 or not changing it when I get 304 since the system tray menu is built every time it is displayed and I always need the user menu to be created before I can insert the navigation apps menu.