### PR TITLE
Put log files somewhere else #221 

### DIFF
--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -102,7 +102,7 @@ void SyncRunFileLog::start(const QString &folderPath)
 
     int length = folderPath.split(QString(QDir::separator())).length();
     const QString filename = foldername + QString(QDir::separator())  ///
-          +"." + folderPath.split(QString(QDir::separator())).at(length - 2) + QLatin1String("_sync.log");
+          + folderPath.split(QString(QDir::separator())).at(length - 2) + QLatin1String("_sync.log");
 
     // When the file is too big, just rename it to an old name.
     QFileInfo info(filename);

--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -95,8 +95,14 @@ void SyncRunFileLog::start(const QString &folderPath)
 {
     const qint64 logfileMaxSize = 1024 * 1024; // 1MiB
 
-    // Note; this name is ignored in csync_exclude.c
-    const QString filename = folderPath + QLatin1String(".owncloudsync.log");
+    const QString foldername = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    if(!QDir(foldername).exists()) {
+        QDir().mkdir(foldername);
+    }
+
+    int length = folderPath.split(QString(QDir::separator())).length();
+    const QString filename = foldername + QString(QDir::separator())  ///
+          +"." + folderPath.split(QString(QDir::separator())).at(length - 2) + QLatin1String("_sync.log");
 
     // When the file is too big, just rename it to an old name.
     QFileInfo info(filename);

--- a/src/gui/syncrunfilelog.h
+++ b/src/gui/syncrunfilelog.h
@@ -19,6 +19,8 @@
 #include <QTextStream>
 #include <QScopedPointer>
 #include <QElapsedTimer>
+#include <QStandardPaths>
+#include <QDir>
 
 #include "syncfileitem.h"
 


### PR DESCRIPTION
 #221 
I have changed the location from the logfiles from the synced folders to the appData folder from:

../Nextcloud/SyncedFolder1/.owncloudsync.log
../Nextcloud/SyncedFolder2/.owncloudsync.log

to [QStandardPaths::AppDataLocation](http://doc.qt.io/qt-5/qstandardpaths.html) 
Linux: ~/.local/share/Nextcloud/SyncedFolder1_sync.log 
          ~/.local/share/Nextcloud/SyncedFolder2_sync.log

macOS: ~/Library/Application Support/Nextcloud/SyncedFolder1_sync.log "
             ~/Library/Application Support/Nextcloud/SyncedFolder2_sync.log " 

Win: C:/Users/<USER>/AppData/Roaming/Nextcloud/SyncedFolder1_sync.log "
        C:/Users/<USER>/AppData/Roaming/Nextcloud/SyncedFolder2_sync.log "

Remaining question is whether or not, the ".owncloudsync.log" pattern should be removed from "ignore this file and dont even show it in the Not Synced list" to keep the code clean and consistent. Problem here is if someone updates the client, and does not manually remove the old logs, the logs will be present in the "Not Synced List". This does not apply for a fresh install with new folders to be synced.

(edit: I made the log files visible)