### PR TITLE
Fix Use of Deprecated trUtf8

### DIFF
--- a/src/libsync/nextcloudtheme.cpp
+++ b/src/libsync/nextcloudtheme.cpp
@@ -47,7 +47,7 @@ QString NextcloudTheme::about() const
               .arg(MIRALL_VERSION_STRING).arg("http://" MIRALL_STRINGIFY(APPLICATION_DOMAIN))
               .arg(MIRALL_STRINGIFY(APPLICATION_DOMAIN));
 
-     re += trUtf8("<p><small>By Klaas Freitag, Daniel Molkentin, Jan-Christoph Borchardt, "
+     re += tr("<p><small>By Klaas Freitag, Daniel Molkentin, Jan-Christoph Borchardt, "
                   "Olivier Goffart, Markus Götz and others.</small></p>");
 
      re += tr("<p>This release was supplied by the Nextcloud GmbH<br />"


### PR DESCRIPTION
Hello, 

This fix Deprecated trUTF8 by QT. 

error : 
`/drone/src/github.com/nextcloud/client/src/libsync/nextcloudtheme.cpp:50:12: warning: 'static QString OCC::NextcloudTheme::trUtf8(const char*, const char*, int)' is deprecated [-Wdeprecated-declarations]
      re += trUtf8("<p><small>By Klaas Freitag, Daniel Molkentin, Jan-Christoph Borchardt, "
            ^
In file included from /opt/qt59/include/QtCore/qobject.h:46:0,
                 from /opt/qt59/include/QtCore/QObject:1,
                 from /drone/src/github.com/nextcloud/client/src/libsync/theme.h:18,
                 from /drone/src/github.com/nextcloud/client/src/libsync/nextcloudtheme.h:18,
                 from /drone/src/github.com/nextcloud/client/src/libsync/nextcloudtheme.cpp:15:
/drone/src/github.com/nextcloud/client/src/libsync/nextcloudtheme.h:28:5: note: declared here
     Q_OBJECT
     ^`