### PR TITLE
Put log files somewhere else #221 (name conflict)

### DIFF
--- a/src/gui/syncrunfilelog.cpp
+++ b/src/gui/syncrunfilelog.cpp
@@ -101,8 +101,23 @@ void SyncRunFileLog::start(const QString &folderPath)
     }
 
     int length = folderPath.split(QString(QDir::separator())).length();
-    const QString filename = foldername + QString(QDir::separator())  ///
-          + folderPath.split(QString(QDir::separator())).at(length - 2) + QLatin1String("_sync.log");
+    QString filenameRaw = foldername + QString(QDir::separator())  ///
+          + folderPath.split(QString(QDir::separator())).at(length - 2);
+    QString filename = filenameRaw + QLatin1String("_sync.log");
+
+    while(QFile::exists(filename)) {    
+       
+       QFile file(filename);
+       file.open(QIODevice::ReadOnly| QIODevice::Text);
+       QTextStream in(&file);
+       QString line = in.readLine();
+
+       if(QString::compare(folderPath,line,Qt::CaseSensitive)!=0) {
+           filename = filenameRaw + QLatin1String("_1") + QLatin1String("_sync.log");
+	   filenameRaw += QLatin1String("_1");
+       }
+       else break;
+    }
 
     // When the file is too big, just rename it to an old name.
     QFileInfo info(filename);
@@ -120,6 +135,7 @@ void SyncRunFileLog::start(const QString &folderPath)
 
 
     if (!exists) {
+        _out << folderPath.toLatin1() << endl;
         // We are creating a new file, add the note.
         _out << "# timestamp | duration | file | instruction | dir | modtime | etag | "
                 "size | fileId | status | errorString | http result code | "


### PR DESCRIPTION
I found a problem regarding my last pull request #253, already talked to @camilasan.

The problem is, if the user adds several folders with the same (local) name, the logfiles get merged.
I thought this is straightforward to fix, but the only function input _folderPath_ carrys not enough information to fix this.
So I had to lable the logfiles (I added the according folderPath into the beginning of the logfile).
**Downside is**: I have to read the files again, which is always open to manipulation and errors, but the worst outcome, if someone is changing the logs is that: **A: new logfile gets created even if there is an existing one. B: logfiles get merged.**

I used the following nameing scheme so far (add "_1"). Do you have any ideas to improve this?

**Example:**
syncing all 3 folders:

_/subfolder/Folder1
/subfolder2/Folder1
/subfolder3/Folder1_

results in ...
![unbenannt](https://user-images.githubusercontent.com/20491467/39192126-c95acce6-47d8-11e8-8861-bbbc90636c51.PNG)

log files look like this now:
![unbenan2nt](https://user-images.githubusercontent.com/20491467/39192391-59f89116-47d9-11e8-9da5-e9983f5e4e52.PNG)

If you have a better solution/idea let me know ;)

