### PR TITLE
Nautilus integration: Not a ColumnProvider

### DIFF
--- a/shell_integration/nautilus/syncstate.py
+++ b/shell_integration/nautilus/syncstate.py
@@ -346,7 +346,7 @@ class MenuExtension(GObject.GObject, Nautilus.MenuProvider):
         socketConnect.sendCommand(action + ":" + filename + "\n")
 
 
-class SyncStateExtension(GObject.GObject, Nautilus.ColumnProvider, Nautilus.InfoProvider):
+class SyncStateExtension(GObject.GObject, Nautilus.InfoProvider):
     def __init__(self):
         GObject.GObject.__init__(self)
 


### PR DESCRIPTION
The nautilus plugin doesn't actually define get_columns(), so pretending
to be a ColumnProvider lead to a critical warning on startup.

PR owncloud/client/pull/6415